### PR TITLE
修正: 開発環境でもAPIのURLを変更しない

### DIFF
--- a/src/components/LayerMenu.vue
+++ b/src/components/LayerMenu.vue
@@ -32,7 +32,6 @@ import {
 } from "@heroicons/vue/24/solid";
 import { searchFeatures, SERVICES } from "@/modules/api";
 import {
-  normalizeAISTUrl,
   getGeoidHeight,
   GEOID_GEOTIFF_PATH,
 } from "@/modules/utils";
@@ -119,7 +118,7 @@ const addFeature = async (feat: Feature, doFlyTo = true) => {
       offsetHeight: geoidHeight * -1,
       center,
       name: feat.properties.title,
-      url: normalizeAISTUrl(feat.properties["3dtiles_url"]),
+      url: feat.properties["3dtiles_url"],
       attribution: feat.properties.author,
       tileStyle: { pointSize: 2 },
     },

--- a/src/components/MapPane.vue
+++ b/src/components/MapPane.vue
@@ -38,7 +38,6 @@ import "cesium/Build/Cesium/Widgets/widgets.css";
 import type { CesiumLayer } from "@/types";
 import {
   setOffsetHeightToTileset,
-  normalizeAISTUrl,
   CESIUM_INITIAL_OPTIONS,
 } from "@/modules/utils";
 import GsiTerrainProvider from "@/modules/gsiTerrain";
@@ -92,7 +91,7 @@ const add = async (layer: CesiumLayer, doFlyTo = true) => {
   attributions.value.push(layer.properties.attribution);
 
   const instance: Cesium3DTileset = viewer.scene.primitives.add(
-    new Cesium3DTileset({ url: normalizeAISTUrl(layer.properties.url) })
+    new Cesium3DTileset({ url: layer.properties.url })
   );
   await instance.readyPromise;
   if (layer.properties.offsetHeight) {

--- a/src/modules/api.ts
+++ b/src/modules/api.ts
@@ -24,9 +24,7 @@
 */
 import type { Service, FeatureCollection } from "@/types";
 
-const API_ROOT = import.meta.env.DEV
-  ? "/3ddb_demo"
-  : "https://gsrt.digiarc.aist.go.jp/3ddb_demo";
+const API_ROOT = "https://gsrt.digiarc.aist.go.jp/3ddb_demo";
 
 const API_DATA_DIR = `${API_ROOT}/api/v1/zipdata/`;
 

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -94,20 +94,9 @@ const setOffsetHeightToTileset = (
   return tileset;
 };
 
-/**
- * 開発環境において産総研の絶対URLを相対URLへ変換 (開発サーバでプロキシするため)
- * @param url
- */
-const normalizeAISTUrl = (url: string) => {
-  return import.meta.env.DEV
-    ? url.replace("https://gsrt.digiarc.aist.go.jp", "")
-    : url;
-};
-
 export {
   GEOID_GEOTIFF_PATH,
   CESIUM_INITIAL_OPTIONS,
   getGeoidHeight,
   setOffsetHeightToTileset,
-  normalizeAISTUrl,
 };


### PR DESCRIPTION
## 問題

- 経緯
  - 当初の開発時は、CORS制約を回避するために、ViteでAPIアクセス先をプロキシしていた
  - 現在公開されているコードでは、Viteでのプロキシ設定自体は削除されている
  - しかし、「環境ごとにURLを書き換える処理」自体は残存していた
- 上記のため、開発環境（ `npm run dev` ）では、APIからデータを取得できていなかった
  - ビルド時（ `npm run build` ）は問題なく動作していた

## 解決

- 開発時・ビルド時、どちらでも同じAPIエンドポイントへアクセスするように修正

（ オリジナル変更: https://github.com/MIERUNE/aist_3ddb_client/pull/4 ）
